### PR TITLE
Convert the data file to utf-8 to avoid expensive entity replacement.

### DIFF
--- a/sexmachine/detector.py
+++ b/sexmachine/detector.py
@@ -1,6 +1,5 @@
 import os.path
 import codecs
-from .mapping import map_name
 
 
 class NoCountryError(Exception):
@@ -33,10 +32,8 @@ class Detector:
     def _parse(self, filename):
         """Opens data file and for each line, calls _eat_name_line"""
         self.names = {}
-        with codecs.open(filename, encoding="iso8859-1") as f:
+        with codecs.open(filename, encoding="utf-8") as f:
             for line in f:
-                if any(map(lambda c: 128 < ord(c) < 160, line)):
-                    line = line.encode("iso8859-1").decode("windows-1252")
                 self._eat_name_line(line.strip())
 
     def _eat_name_line(self, line):
@@ -44,7 +41,7 @@ class Detector:
         if line[0] not in "#=":
             parts = line.split()
             country_values = line[30:-1]
-            name = map_name(parts[1])
+            name = parts[1]
             if not self.case_sensitive:
                 name = name.lower()
 


### PR DESCRIPTION
Previously the file was encoded as iso8859-1 and the non-iso characters
were encoded as entities like <ij>, that had to be replaced by their
equivalent in unicode when the detector was spawned. This operation was
very expensive and modern encodings like utf-8 allow saving the special
characters directly in the file, avoiding the extra initialization time.
